### PR TITLE
some changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master", "development" ]
+  pull_request:
+    branches: [ "master", "development" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --release --verbose
+    - name: Run tests
+      run: cargo test --release --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  AMARI_TOKEN: ${{ secrets.AMARI_TOKEN }}
 
 jobs:
   build:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+chain_width = 80
+group_imports = "StdExternalCrate"
+imports_layout = "HorizontalVertical"
+wrap_comments = true

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,6 +25,7 @@ use crate::defs::{FetchType, Leaderboard, Rewards, User, Users, BASE_URL};
 pub struct AmariClient {
     client: Client,
     cacher: Cache,
+    cache_enabled: bool,
 }
 
 impl AmariClient {
@@ -39,17 +40,17 @@ impl AmariClient {
         AmariClient {
             client: client.default_headers(default_header).build().unwrap(),
             cacher: Cache::new(60, 256 * 1024 * 1024),
+            cache_enabled: true,
         }
     }
 
-    pub async fn fetch_user(
-        &mut self,
-        guild_id: u64,
-        user_id: u64,
-        cache: bool,
-    ) -> reqwest::Result<User> {
+    pub fn toggle_cache(&mut self, enable: bool) {
+        self.cache_enabled = enable;
+    }
+
+    pub async fn fetch_user(&mut self, guild_id: u64, user_id: u64) -> reqwest::Result<User> {
         let url = format!("{BASE_URL}/guild/{guild_id}/member/{user_id}");
-        if cache {
+        if self.cache_enabled {
             let key = FetchType::User(guild_id, user_id);
             let data = self.cacher.get(&key);
 
@@ -72,9 +73,8 @@ impl AmariClient {
         &mut self,
         guild_id: u64,
         user_ids: Vec<u64>,
-        cache: bool,
     ) -> reqwest::Result<Users> {
-        if cache {
+        if self.cache_enabled {
             let mut users: Vec<User> = Vec::new();
             let mut uncached_users: Vec<u64> = Vec::new();
 
@@ -163,9 +163,8 @@ impl AmariClient {
         guild_id: u64,
         page: Option<u32>,
         limit: Option<u32>,
-        cache: bool,
     ) -> Result<Rewards, reqwest::Error> {
-        if cache {
+        if self.cache_enabled {
             let key = FetchType::Reward(guild_id, page.unwrap_or(1), limit.unwrap_or(50));
             if let Some(rewards) = self.cacher.get(&key) {
                 return Ok(rewards.downcast_ref::<Rewards>().unwrap().clone());

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,8 +18,8 @@ use crate::cache::Cache;
 ///
 /// dotenv().expect("Failed to load .env file");
 ///
-/// let mut client = AmariClient::new();
-/// client.init(env::var("AMARI_TOKEN").unwrap());
+/// let token = env::var("AMARI_TOKEN").unwrap();
+/// let mut client = AmariClient::new(token);
 /// ```
 #[derive(Debug, Clone)]
 pub struct AmariClient {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::defs::FetchType;
+
 #[derive(Debug, Clone)]
 pub struct CacheEntry {
     data: Arc<dyn std::any::Any + Send + Sync>,
@@ -23,7 +25,7 @@ impl CacheEntry {
 pub struct Cache {
     ttl: u32,
     max_bytes: usize,
-    cache: HashMap<(String, u64, u64, Option<u64>), CacheEntry>, // TODO: Fix this type.
+    cache: HashMap<FetchType, CacheEntry>, // TODO: Fix this type.
     total_size: usize,
 }
 
@@ -37,10 +39,7 @@ impl Cache {
         }
     }
 
-    pub fn get(
-        &mut self,
-        key: &(String, u64, u64, Option<u64>),
-    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+    pub fn get(&mut self, key: &FetchType) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         let entry = self.cache.get(key);
         match entry {
             Some(ent) => {
@@ -55,11 +54,7 @@ impl Cache {
         }
     }
 
-    pub fn set(
-        &mut self,
-        key: &(String, u64, u64, Option<u64>),
-        data: Arc<dyn std::any::Any + Send + Sync>,
-    ) {
+    pub fn set(&mut self, key: &FetchType, data: Arc<dyn std::any::Any + Send + Sync>) {
         // Dirty downcasting to unsigned char* type and get length.
         let data_size = data.downcast_ref::<Vec<u8>>().map(|v| v.len()).unwrap_or(0);
 
@@ -73,7 +68,7 @@ impl Cache {
         self.total_size += data_size;
     }
 
-    fn remove_entry(&mut self, key: &(String, u64, u64, Option<u64>)) {
+    fn remove_entry(&mut self, key: &FetchType) {
         let ent = self.cache.remove(key);
         if let Some(ent) = ent {
             self.total_size -= ent.size;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,7 +37,10 @@ impl Cache {
         }
     }
 
-    pub fn get(&mut self, key: &(String, u64, u64, Option<u64>)) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+    pub fn get(
+        &mut self,
+        key: &(String, u64, u64, Option<u64>),
+    ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         let entry = self.cache.get(key);
         match entry {
             Some(ent) => {
@@ -52,7 +55,11 @@ impl Cache {
         }
     }
 
-    pub fn set(&mut self, key: &(String, u64, u64, Option<u64>), data: Arc<dyn std::any::Any + Send + Sync>) {
+    pub fn set(
+        &mut self,
+        key: &(String, u64, u64, Option<u64>),
+        data: Arc<dyn std::any::Any + Send + Sync>,
+    ) {
         // Dirty downcasting to unsigned char* type and get length.
         let data_size = data.downcast_ref::<Vec<u8>>().map(|v| v.len()).unwrap_or(0);
 

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -4,10 +4,22 @@ use serde_with::{serde_as, DisplayFromStr};
 /// Base URL for AmariBot API.
 pub const BASE_URL: &'static str = "https://amaribot.com/api/v1";
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum FetchType {
+    /// (guild id, page, limit)
+    Leaderboard(u64, u32, u32),
+    /// (guild id, page, limit)
+    WeeklyLeaderboard(u64, u32, u32),
+    /// (guild id, page, limit)
+    Reward(u64, u32, u32),
+    /// (guild id, user id)
+    User(u64, u64),
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Leaderboard {
     pub count: u64,
-    #[serde(rename="data")]
+    #[serde(rename = "data")]
     pub users: Vec<User>,
     pub total_count: u64,
 }
@@ -15,21 +27,21 @@ pub struct Leaderboard {
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct User {
-    #[serde_as(as="DisplayFromStr")]
+    #[serde_as(as = "DisplayFromStr")]
     pub id: u64,
     pub username: String,
     pub exp: u32,
     pub level: Option<u32>,
-    
-    #[serde(rename="weeklyExp")]
+
+    #[serde(rename = "weeklyExp")]
     pub weekly_exp: Option<u32>,
 }
 
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Users {
-    #[serde_as(as="DisplayFromStr")]
-    #[serde(rename="guild")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(rename = "guild")]
     pub guild_id: u64,
     pub members: Vec<User>,
     pub total_members: usize,
@@ -39,16 +51,16 @@ pub struct Users {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RewardRole {
-    #[serde_as(as="DisplayFromStr")]
-    #[serde(rename="roleID")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(rename = "roleID")]
     pub role_id: u64,
-    pub level: u64
+    pub level: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rewards {
     pub count: u64,
-    #[serde(rename="data")]
+    #[serde(rename = "data")]
     pub roles: Vec<RewardRole>,
 }
 

--- a/tests/cache_test.rs
+++ b/tests/cache_test.rs
@@ -2,8 +2,8 @@ mod tests {
     use amari_rs::api::AmariClient;
     use dotenvy::dotenv;
 
-    use std::sync::Arc;
     use amari_rs::cache::Cache;
+    use std::sync::Arc;
 
     #[test]
     fn test_all() {
@@ -18,7 +18,9 @@ mod tests {
         assert_eq!(data1.len(), 3);
         dbg!(&data1[0]);
 
-        struct X { test: u64 }
+        struct X {
+            test: u64,
+        }
         let data2 = X { test: 4423 };
 
         cache.set(&("test2".into(), 112, 2, None), Arc::new(data2));
@@ -34,12 +36,12 @@ mod tests {
     async fn cache_bench() {
         dotenv().expect("Failed to load .env file");
 
-        let mut client = AmariClient::new();
-        client.init(std::env::var("AMARI_TOKEN").unwrap());
+        let token = std::env::var("AMARI_TOKEN").unwrap();
+        let mut client = AmariClient::new(token);
 
         let start = std::time::Instant::now();
         let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
-        
+
         println!("Before cache: {}", start.elapsed().as_secs_f64());
         println!("User: {:#?}", user.unwrap().id);
 
@@ -52,7 +54,10 @@ mod tests {
         let start = std::time::Instant::now();
         let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
-        println!("After cache (second time): {}", start.elapsed().as_secs_f64());
+        println!(
+            "After cache (second time): {}",
+            start.elapsed().as_secs_f64()
+        );
         println!("User: {:#?}", user.unwrap());
     }
 }

--- a/tests/cache_test.rs
+++ b/tests/cache_test.rs
@@ -45,19 +45,19 @@ mod tests {
         let mut client = AmariClient::new(token);
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
         println!("Before cache: {}", start.elapsed().as_secs_f64());
         println!("User: {:#?}", user.unwrap().id);
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
         println!("After cache: {}", start.elapsed().as_secs_f64());
         println!("User: {:#?}", user.unwrap());
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
         println!(
             "After cache (second time): {}",

--- a/tests/cache_test.rs
+++ b/tests/cache_test.rs
@@ -45,19 +45,19 @@ mod tests {
         let mut client = AmariClient::new(token);
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
 
         println!("Before cache: {}", start.elapsed().as_secs_f64());
         println!("User: {:#?}", user.unwrap().id);
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
 
         println!("After cache: {}", start.elapsed().as_secs_f64());
         println!("User: {:#?}", user.unwrap());
 
         let start = std::time::Instant::now();
-        let user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
+        let user = client.fetch_user(1087783849183940708, 607197619193643029).await;
 
         println!(
             "After cache (second time): {}",

--- a/tests/cache_test.rs
+++ b/tests/cache_test.rs
@@ -1,5 +1,5 @@
 mod tests {
-    use amari_rs::api::AmariClient;
+    use amari_rs::{api::AmariClient, defs::FetchType};
     use dotenvy::dotenv;
 
     use amari_rs::cache::Cache;
@@ -10,9 +10,11 @@ mod tests {
         let mut cache = Cache::new(1000, 256 * 1024 * 1024);
         let test1: Vec<u8> = vec![1, 2, 3];
 
-        cache.set(&("test".into(), 111, 0, None), Arc::new(test1.clone()));
+        let key = FetchType::User(111, 0);
+        cache.set(&key, Arc::new(test1.clone()));
 
-        let grab1 = cache.get(&("test".into(), 111, 0, None)).unwrap();
+        let new_key = FetchType::User(111, 0);
+        let grab1 = cache.get(&new_key).unwrap();
         let data1 = grab1.downcast_ref::<Vec<u8>>().unwrap();
 
         assert_eq!(data1.len(), 3);
@@ -23,8 +25,11 @@ mod tests {
         }
         let data2 = X { test: 4423 };
 
-        cache.set(&("test2".into(), 112, 2, None), Arc::new(data2));
-        let grab2 = cache.get(&("test2".into(), 112, 2, None)).unwrap();
+        let key = FetchType::User(112, 2);
+        cache.set(&key, Arc::new(data2));
+
+        let new_key = FetchType::User(112, 2);
+        let grab2 = cache.get(&new_key).unwrap();
 
         let data2 = grab2.downcast_ref::<X>().unwrap();
         assert_eq!(data2.test, 4423);

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -6,9 +6,7 @@ mod tests {
     async fn test_client() {
         dotenv().expect("Failed to load .env file");
         let token: String = std::env::var("AMARI_TOKEN").unwrap();
-
-        let mut client = AmariClient::new();
-        client.init(token);
+        let mut client = AmariClient::new(token);
 
         let mut user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
         dbg!(&user);
@@ -16,10 +14,19 @@ mod tests {
         user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
         assert_eq!(user.unwrap().id, 607197619193643029);
-        let users = client.fetch_users(1087783849183940708, vec![790507101868654602, 607197619193643029], true).await;
+        let users = client
+            .fetch_users(
+                1087783849183940708,
+                vec![790507101868654602, 607197619193643029],
+                true,
+            )
+            .await;
 
         dbg!(&users);
-        assert_eq!(users.unwrap().get_user(607197619193643029).unwrap().id, 607197619193643029);
+        assert_eq!(
+            users.unwrap().get_user(607197619193643029).unwrap().id,
+            607197619193643029
+        );
 
         let lb = client.fetch_leaderboard(1087783849183940708, None, None, None, Some(5)).await;
         dbg!(&lb);

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -8,17 +8,16 @@ mod tests {
         let token: String = std::env::var("AMARI_TOKEN").unwrap();
         let mut client = AmariClient::new(token);
 
-        let mut user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
+        let mut user = client.fetch_user(1087783849183940708, 607197619193643029).await;
         dbg!(&user);
 
-        user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
+        user = client.fetch_user(1087783849183940708, 607197619193643029).await;
 
         assert_eq!(user.unwrap().id, 607197619193643029);
         let users = client
             .fetch_users(
                 1087783849183940708,
                 vec![790507101868654602, 607197619193643029],
-                true,
             )
             .await;
 
@@ -32,7 +31,7 @@ mod tests {
         dbg!(&lb);
 
         assert_eq!(lb.unwrap().count, 5);
-        let rewards = client.fetch_rewards(1087783849183940708, None, Some(5), true).await;
+        let rewards = client.fetch_rewards(1087783849183940708, None, Some(5)).await;
 
         dbg!(&rewards);
         assert_eq!(rewards.unwrap().count, 5);

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -8,16 +8,17 @@ mod tests {
         let token: String = std::env::var("AMARI_TOKEN").unwrap();
         let mut client = AmariClient::new(token);
 
-        let mut user = client.fetch_user(1087783849183940708, 607197619193643029).await;
+        let mut user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
         dbg!(&user);
 
-        user = client.fetch_user(1087783849183940708, 607197619193643029).await;
+        user = client.fetch_user(1087783849183940708, 607197619193643029, true).await;
 
         assert_eq!(user.unwrap().id, 607197619193643029);
         let users = client
             .fetch_users(
                 1087783849183940708,
                 vec![790507101868654602, 607197619193643029],
+                true,
             )
             .await;
 
@@ -31,7 +32,7 @@ mod tests {
         dbg!(&lb);
 
         assert_eq!(lb.unwrap().count, 5);
-        let rewards = client.fetch_rewards(1087783849183940708, None, Some(5)).await;
+        let rewards = client.fetch_rewards(1087783849183940708, None, Some(5), true).await;
 
         dbg!(&rewards);
         assert_eq!(rewards.unwrap().count, 5);


### PR DESCRIPTION
- improved the cache key type (no longer a 4-tuple for all cases)
- combined `AmariClient::new` and `client.init()` into one function call through `new()`
- also ran rustfmt, my IDE does this automatically and i've included the toml file with my settings, feel free to change it and rerun the formatter however you like

## Summary by Sourcery

Refactor the AmariClient to simplify initialization and cache management, and introduce a new cache key type. Add a CI workflow for automated builds and tests, and format the codebase using rustfmt.

Enhancements:
- Simplify cache key type by replacing 4-tuple with a FetchType enum for better clarity and maintainability.
- Combine AmariClient::new and client.init() into a single function call for easier client initialization.
- Introduce a toggle_cache method to enable or disable caching globally for the AmariClient.

CI:
- Add a GitHub Actions workflow for building and testing the Rust project on push and pull request events.

Chores:
- Run rustfmt to format the codebase according to the provided rustfmt.toml configuration.